### PR TITLE
updated reference to Kon

### DIFF
--- a/assets/json/characters.json
+++ b/assets/json/characters.json
@@ -819,7 +819,7 @@
     "image" : "616Mimihagi_profile"
   },
   {
-    "name" : "Kon",
+    "name" : "Mod Soul Kon",
     "race" : "Modified Soul",
     "affiliation" : "Kurosaki Clinic",
     "status" : "Alive",


### PR DESCRIPTION
BUG: reference to Object.name "Kon" was overlapping with Regex formula for Object.name "Akon"
FIX: change reference of Object.name "Kon" to Object.name "Mod Soul Kon"