### PR TITLE
updated lowHigh${value} scripts

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
             <strong></strong><p id="aboutText" style="display: none; font-family: BleachTYBW; text-align: left;">
                 <em>THOUSAND YEAR BLOOD WAR-DLE</em> is a game based off the New York Times' Wordle minigame where you take turns guessing what a hidden word is!
                 <br><br>To play, you enter a guess into the text bar, and submit it! The game will then tell you whether your answer is <span style="color: #32cd32">CORRECT</span> or <span style="color: #cc3300">INCORRECT</span>, and if incorrect, will highlight the mismatching information provided <span style="color: #cc3300">RED</span>.
+                <br><br>The game will also indicate to you when your guess' measurements are wrong! A "🔺" next to a guess' value means the answer's value is greater than the guess', a "🔻" indicates that the answer's is less, and a "❌" means the value type is incorrect! (ex: if the answer doesn't have a provided height, the "❌" will always be displayed, and vice versa!)
                 <br><br>Created by <a href="https://www.linkedin.com/in/j4meslii/" target="_blank">James Li</a> using vanilla JavaScript/HTML5/CSS3. View the repository <a href="https://github.com/j4mesli/tybwardle.io" target="_blank">here</a>!
                 <br><br><em>BLEACH</em>, it's characters, and their likenesses are all owned by VIZ Media, Shueisha, and Tite Kubo. Please support the official release!
             </p></strong>

--- a/index.js
+++ b/index.js
@@ -225,19 +225,29 @@ guessFunc = async (guess) => {
     else {
         const imageURL = "assets/images/" + guess.image + ".jpg"
         const lowHighWeight = () => {
-            if (guess.weight < answer.weight) {
-                return "🔺";
+            if (answer.weight === 0) {
+                return "❌";
             }
             else {
-                return "🔻";
+                if (parseInt(guess.weight) < parseInt(answer.weight)) {
+                    return "🔺";
+                }
+                else {
+                    return "🔻";
+                }
             }
         }
         const lowHighHeight = () => {
-            if (guess.weight < answer.weight) {
-                return "🔺";
+            if (answer.height === 0) {
+                return "❌";
             }
             else {
-                return "🔻";
+                if (guess.height < answer.height) {
+                    return "🔺";
+                }
+                else {
+                    return "🔻";
+                }
             }
         }
         const html = `
@@ -248,7 +258,7 @@ guessFunc = async (guess) => {
             <div class="guessText"><strong><h4 class="shrinkMobile" style="font-family: BleachTYBW; color: ${guess.affiliation === answer.affiliation ? "#32cd32" : "#cc3300"}">${guess.affiliation}</h4></strong></div>
             <div class="guessText"><strong><h4 class="shrinkMobile" style="font-family: BleachTYBW; color: ${guess.status === answer.status ? "#32cd32" : "#cc3300"}">${guess.status}</h4></strong></div>
             <div class="guessText"><strong><h4 class="shrinkMobile" style="font-family: BleachTYBW; color: ${guess.height === answer.height ? "#32cd32" : "#cc3300"}">${guess.height === 0 ? "N/A" : guess.height + " cm"} ${guess.height !== 0 ? lowHighHeight() : ""}</h4></strong></div>
-            <div class="guessText"><strong><h4 class="shrinkMobile" style="font-family: BleachTYBW; color: ${guess.weight === answer.weight ? "#32cd32" : "#cc3300"}">${guess.weight === 0 ? "N/A" : guess.weight + " kg"} ${guess.weight !== 0 ? lowHighHeight() : ""}</h3></strong></div>
+            <div class="guessText"><strong><h4 class="shrinkMobile" style="font-family: BleachTYBW; color: ${guess.weight === answer.weight ? "#32cd32" : "#cc3300"}">${guess.weight === 0 ? "N/A" : guess.weight + " kg"} ${guess.weight !== 0 ? lowHighWeight() : ""}</h3></strong></div>
         </div>
         `;
         guesses.innerHTML += html;


### PR DESCRIPTION
BUG: const lowHighWeight and const lowHighHeight were both fixed around the guess.height, with no functionality to detect whether or not answer values existed (ex: answer w/ weight of 150kg and height of N/A would display down arrows for a guess w/ weight 200kg and height 100 even though answer.weight was lower and answer.height didn't exist.
FIX: updated functions to include functionality for detecting whether or not Object.weight and Object.height exist, and updated index.html to include meanings of different symbols "🔻", "🔺", and "❌"